### PR TITLE
Increase the number of MIDI input channels from 1 to 16

### DIFF
--- a/Genny/src/base/VSTBase.cpp
+++ b/Genny/src/base/VSTBase.cpp
@@ -345,7 +345,7 @@ void VSTBase::MidiFlush()
 
 VstInt32 VSTBase::getNumMidiInputChannels()
 {
-	return 1;
+	return 16;
 }
 
 VstInt32 VSTBase::getNumMidiOutputChannels()


### PR DESCRIPTION
This fix makes the VST advertise itself as having 16 MIDI input channels. This means that (for Ableton Live at least), you can have Genny sitting on one track in the mixer and route the outputs of other MIDI tracks in the mixer to specific channels of Genny.

Without this change, you can still route MIDI tracks to the Genny track, but Genny only receives MIDI on channel 1.

I tested this in Windows with Ableton Live Standard and this seems to work as expected.